### PR TITLE
Update managedinstalls.py, item_list item status check

### DIFF
--- a/scripts/managedinstalls.py
+++ b/scripts/managedinstalls.py
@@ -68,7 +68,7 @@ def remove_result(item_list, install_list):
     """Update list according to result"""
     for item in item_list:
         # install_list[item['name']]['time'] = item.time
-        if item.status == 0:
+        if item['status'] == 0:
             install_list[item['name']]['installed'] = False
             install_list[item['name']]['status'] = 'uninstalled'
         else:
@@ -96,7 +96,7 @@ def install_result(item_list, install_list):
         else:
             name = item['name']
 
-        if item.status == 0:
+        if item['status'] == 0:
             install_list[name]['installed'] = True
             install_list[name]['status'] = 'install_succeeded'
         else:


### PR DESCRIPTION
Updated the incorrectly checked item list item status.

if item.status == 0 ---> if item['status'] == 0.

The first example (the old way) gives an error: dict object has no attribute status.

I noticed that in the latest managedinstalls.py, install_result function had it the right way (if item['status'] == 0), but the remove_result function had it the old 'wrong' way.